### PR TITLE
Rhel 7 160117

### DIFF
--- a/recipes/_install_ssh_rhel.rb
+++ b/recipes/_install_ssh_rhel.rb
@@ -1,9 +1,9 @@
-package_list = %w(nscd openldap openldap-clients nss-pam-ldapd authconfig policycoreutils-python oddjob)
+package_list = %w(nscd openldap openldap-clients nss-pam-ldapd authconfig policycoreutils-python)
 
 if node.platform == 'redhat'
   if Chef::VersionConstraint.new('~> 7.0').include?(node['platform_version'])
     # this is needed for mkhomedir to work on rhel
-    package_list << "oddjob-mkhomedir"
+    package_list += %w(oddjob oddjob-mkhomedir)
 
     # this package doesn't exist anymore on rhel 7
     package_list -= 'openssl-perl'

--- a/recipes/_install_ssh_rhel.rb
+++ b/recipes/_install_ssh_rhel.rb
@@ -1,5 +1,14 @@
-package_list=%w(nscd openldap openldap-clients nss-pam-ldapd authconfig openssl-perl policycoreutils-python oddjob)
-package_list << "oddjob-mkhomedir" if Chef::VersionConstraint.new('~> 7.0').include?(node['platform_version'])
+package_list = %w(nscd openldap openldap-clients nss-pam-ldapd authconfig policycoreutils-python oddjob)
+
+if node.platform == 'redhat'
+  if Chef::VersionConstraint.new('~> 7.0').include?(node['platform_version'])
+    # this is needed for mkhomedir to work on rhel
+    package_list << "oddjob-mkhomedir"
+
+    # this package doesn't exist anymore on rhel 7
+    package_list -= 'openssl-perl'
+  end
+end
 
 package_list.each do |pkg|
   package pkg do

--- a/recipes/_install_ssh_rhel.rb
+++ b/recipes/_install_ssh_rhel.rb
@@ -1,12 +1,22 @@
-package_list = %w(nscd openldap openldap-clients nss-pam-ldapd authconfig policycoreutils-python)
+package_list = %W(
+  nscd
+  openldap
+  openldap-clients
+  nss-pam-ldapd
+  authconfig
+  policycoreutils-python
+  oddjob
+)
 
 if node.platform == 'redhat'
   if Chef::VersionConstraint.new('~> 7.0').include?(node['platform_version'])
-    # this is needed for mkhomedir to work on rhel
-    package_list += %w(oddjob oddjob-mkhomedir)
+    # this is needed for mkhomedir to work on rhel 7
+    package_list << 'oddjob-mkhomedir'
 
-    # this package doesn't exist anymore on rhel 7
-    package_list -= 'openssl-perl'
+    # this package doesn't exist anymore on rhel 7 in
+    # the main repo and doesn't appear to be required
+    # TODO: figure out if it can be removed altogether
+    package_list -= ['openssl-perl']
   end
 end
 

--- a/recipes/_install_ssh_rhel.rb
+++ b/recipes/_install_ssh_rhel.rb
@@ -1,10 +1,3 @@
-# amazon linux uses 'current' as $releasever
-# but packages from EL7 work on it.
-# CentOS and RHEL actually have '6' or '7' in the variable.
-releasever = {
-  'amazon' => '7'
-}[node.platform] || '$releasever'
-
 package_list=%w(nscd openldap openldap-clients nss-pam-ldapd authconfig openssl-perl policycoreutils-python oddjob)
 package_list << "oddjob-mkhomedir" if Chef::VersionConstraint.new('~> 7.0').include?(node['platform_version'])
 
@@ -23,6 +16,13 @@ cookbook_file '/etc/pki/rpm-gpg/RPM-GPG-KEY-Conjur' do
   mode '644'
   source 'apt.key'
 end
+
+# amazon linux uses 'current' as $releasever
+# but packages from EL7 work on it.
+# CentOS and RHEL actually have '6' or '7' in the variable.
+releasever = {
+  'amazon' => '7'
+}[node.platform] || '$releasever'
 
 yum_repository 'conjur' do
   description 'Conjur Inc.'

--- a/recipes/_install_ssh_rhel.rb
+++ b/recipes/_install_ssh_rhel.rb
@@ -1,4 +1,14 @@
-%w(nscd openldap openldap-clients nss-pam-ldapd authconfig openssl-perl policycoreutils-python).each do |pkg|
+# amazon linux uses 'current' as $releasever
+# but packages from EL7 work on it.
+# CentOS and RHEL actually have '6' or '7' in the variable.
+releasever = {
+  'amazon' => '7'
+}[node.platform] || '$releasever'
+
+package_list=%w(nscd openldap openldap-clients nss-pam-ldapd authconfig openssl-perl policycoreutils-python oddjob)
+package_list << "oddjob-mkhomedir" if Chef::VersionConstraint.new('~> 7.0').include?(node['platform_version'])
+
+package_list.each do |pkg|
   package pkg do
     options '-y'
   end
@@ -13,13 +23,6 @@ cookbook_file '/etc/pki/rpm-gpg/RPM-GPG-KEY-Conjur' do
   mode '644'
   source 'apt.key'
 end
-
-# amazon linux uses 'current' as $releasever
-# but packages from EL7 work on it.
-# CentOS and RHEL actually have '6' or '7' in the variable.
-releasever = {
-  'amazon' => '7'
-}[node.platform] || '$releasever'
 
 yum_repository 'conjur' do
   description 'Conjur Inc.'

--- a/test/integration/default/serverspec/install_spec.rb
+++ b/test/integration/default/serverspec/install_spec.rb
@@ -5,8 +5,8 @@ describe group('conjur') do
 end
 
 describe file('/etc/nsswitch.conf') do
-  its(:content) { should match(/^passwd\:\s+compat ldap$/)}
-  its(:content) { should match(/^group\:\s+compat ldap$/)}
+  its(:content) { should match(/^passwd\:.*ldap/)}
+  its(:content) { should match(/^group\:.*ldap/)}
 end
 
 describe user('authkeylookup') do


### PR DESCRIPTION
Per the RHEL 7 doc https://access.redhat.com/solutions/3972 (subscription required, unfortunately, though you can see it with a trial subscription), `pam_mkhomedir` doesn't work any more when SELinux is enabled. Use `pam_oddjob_mkhomedir`, which the document claims will work on RHEL 4, 5, 6, and 7.