### PR TITLE
Xenial bugfixes (CONJ-4313)

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -7,7 +7,7 @@ GRAPH
   apt (5.1.0)
     compat_resource (>= 12.16.3)
   compat_resource (12.19.0)
-  conjur (0.4.4)
+  conjur (0.4.5)
     apt (~> 5.1.0)
     sshd-service (>= 0.0.0)
     yum (~> 4.2.0)

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -6,7 +6,7 @@ DEPENDENCIES
 GRAPH
   apt (5.1.0)
     compat_resource (>= 12.16.3)
-  compat_resource (12.19.0)
+  compat_resource (12.19.1)
   conjur (0.4.5)
     apt (~> 5.1.0)
     sshd-service (>= 0.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.4.5
 
-* Fix some issues on xenial.
+* Fix some issues on Ubuntu 16.04 preventing mkhomedir and logshipper from working correctly.
 
 # 0.4.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.5
+
+* Fix some issues on xenial.
+
 # 0.4.4
 
 * Change repository addresses to {apt,yum}.conjur.org.

--- a/files/ubuntu-16.04/systemd/logshipper.service
+++ b/files/ubuntu-16.04/systemd/logshipper.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Conjur log shipping service
+Documentation=https://developer.conjur.net
+Wants=rsyslog.service
+Before=rsyslog.service
+
+[Service]
+ExecStartPre=-/bin/rm /var/run/logshipper
+ExecStartPre=/usr/bin/mkfifo --context --mode 0460 /var/run/logshipper
+ExecStartPre=/bin/chown logshipper:syslog /var/run/logshipper
+ExecStart=/usr/sbin/logshipper -n /var/run/logshipper
+Restart=always
+User=logshipper
+Group=conjur
+PermissionsStartOnly=true
+
+[Install]
+RequiredBy=rsyslog.service

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer       'Conjur, Inc'
 maintainer_email 'support@conjur.net'
 license          'MIT License'
 description      'Installs/Configures conjur'
-version          '0.4.4'
+version          '0.4.5'
 
 recipe "conjur::install", "Installs Conjur base packages and configuration, suitable for a foundation image."
 

--- a/recipes/_install_ssh_debian.rb
+++ b/recipes/_install_ssh_debian.rb
@@ -5,10 +5,6 @@ cookbook_file "/tmp/ldap.seed" do
   source "ldap.seed"
 end
 
-cookbook_file "/usr/share/pam-configs/mkhomedir" do
-  source "mkhomedir"
-end
-
 execute "debconf-set-selections /tmp/ldap.seed"
 
 pkgs = %w(debconf nss-updatedb nscd libpam-mkhomedir ldap-utils ldap-client libpam-ldapd libnss-ldapd)
@@ -20,6 +16,24 @@ for pkg in pkgs
         options "-qq"
       end
     end
+
+cookbook_file "/usr/share/pam-configs/mkhomedir" do
+  source "mkhomedir"
+end
+
+# pam-auth-update is broken on xenial, see
+# https://bugs.launchpad.net/ubuntu/+source/pam/+bug/682662
+execute 'workaround Ubuntu bug #682662' do
+  command "sed -i '/mkhomedir/d' /var/lib/pam/seen"
+  only_if do
+    # annoyingly the bug is marked WONTFIX so might as well do it for all ubuntus >= 16.04
+    [
+      (node['platform'] == 'ubuntu'),
+      (node['platform_version'] >= '16.04'),
+      File.exists?('/var/lib/pam/seen'),
+    ].all?
+  end
+end
 
 execute "pam-auth-update" do
   command "pam-auth-update --package"

--- a/spec/install_spec.rb
+++ b/spec/install_spec.rb
@@ -48,7 +48,16 @@ describe "conjur::install" do
       expect(subject).to add_apt_repository("conjur")
       expect(subject).to install_package("logshipper")
     end
+
+    context "version 16.04" do
+      let(:version) { '16.04' }
+      it "creates logshipper pipe with syslog group" do
+        expect(subject).to render_file('/etc/systemd/system/logshipper.service')
+          .with_content /chown logshipper:syslog/
+      end
+    end
   end
+
   context "centos platform" do
     let(:platform) { 'centos' }
     let(:version) { '6.2' }

--- a/spec/install_spec.rb
+++ b/spec/install_spec.rb
@@ -31,11 +31,11 @@ describe "conjur::install" do
     end
   end
   
-  context "ubuntu platform" do
+  context "on ubuntu platform" do
     let(:platform) { 'ubuntu' }
     let(:version) { '12.04' }
     before {
-      chef_run.node.automatic.platform_family = 'debian'
+      chef_run.node.automatic['platform_family'] = 'debian'
     }
     
     it_behaves_like "common installation"
@@ -54,8 +54,8 @@ describe "conjur::install" do
     let(:version) { '6.2' }
 
     before {
-      chef_run.node.automatic.platform_family = 'rhel'
-      chef_run.node.automatic.conjur.selinux_enabled = true
+      chef_run.node.automatic['platform_family'] = 'rhel'
+      chef_run.node.automatic['conjur']['selinux_enabled'] = true
     }
     
     it_behaves_like "common installation"

--- a/test/integration/default/serverspec/install_spec.rb
+++ b/test/integration/default/serverspec/install_spec.rb
@@ -30,3 +30,7 @@ end
 describe package("nss-pam-ldapd"), :if => os[:family] == 'rhel' do
   it { should be_installed }
 end
+
+describe file("/etc/pam.d/common-session") do
+  its(:content) { should match /mkhomedir/ }
+end


### PR DESCRIPTION
Verifying it works is unfortunately relatively involved, but here are the steps:
1. build a package with `rake package`,
1. spin up a Conjur appliance and a xenial host in AWS,
1. configure the appliance,
1. create a host and a user there (not locally, lest `http://localhost` will need end up in config; or replace it in config with the correct **https** url),
1. add a public key for the user,
1. conjurize the target, without `--ssh` (this will set up Conjur identity and configuration),
1. install chef on the target (`curl -L https://www.opscode.com/chef/install.sh | sudo bash`),
1. *scp* the package built in 1. to the target,
1. run chef with `sudo chef-solo --recipe-url <package path> -o conjur`
1. verify that *ssh* to target with key from 5. fails,
1. grant execute on the host to the user,
1. verify that you can now *ssh*,
1. verify that home directory for the user has been created,
1. verify that ssh audit logs appear in Conjur audit.

Whether or not the reviewer wants to go through all that (and it should be automatically tested by the integration tests, and it will, and there is a story for that in JIRA), after merging please go through steps 3.--6. of *PUBLISH.md* to publish the release.